### PR TITLE
Fix Phaser loading on Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,15 @@ This repository now includes a minimal [Phaser.js](https://phaser.io) prototype 
    npm start
    ```
    This runs **live-server** from the project root and automatically opens
-   `public/index.html` in your browser so the Phaser script can load from
+   `public/index.html` in your browser. Phaser is loaded from a CDN so the
+   page works even when deploying to hosts like Vercel that do not serve
    `node_modules`.
 
 You should see a window with a red square rendered by the Phaser game loop. This serves as the project foundation for future gameplay features.
+
+## Deploying to Vercel
+
+The `public` folder can be deployed directly as a static site. Because the
+Phaser library is loaded from a CDN, you don't need to include `node_modules`
+in your deployment. Simply configure Vercel to serve the `public` directory and
+the prototype should run without 404 errors.

--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,8 @@
   </style>
 </head>
 <body>
-  <script src="../node_modules/phaser/dist/phaser.js"></script>
+  <!-- Load Phaser from CDN so deployments don't need local node_modules -->
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
   <script src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Phaser from a CDN instead of node_modules
- update local development instructions
- add a short note for deploying on Vercel

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864cd2430988326b975d2c6e7b1500c