### PR TITLE
Add registration input validation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,7 @@
 <body>
   <div id="registration-container">
     <form id="registration-form">
+      <div id="error-message" style="color:red"></div>
       <input type="text" id="username" placeholder="Username" required />
       <input type="email" id="email" placeholder="Email" required />
       <input type="password" id="password" placeholder="Password" required />

--- a/public/main.js
+++ b/public/main.js
@@ -28,6 +28,7 @@ const game = new Phaser.Game(config);
 
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('registration-form');
+  const errorEl = document.getElementById('error-message');
   if (!form) return;
   form.addEventListener('submit', e => {
     e.preventDefault();
@@ -35,11 +36,28 @@ document.addEventListener('DOMContentLoaded', () => {
     const email = form.email.value.trim();
     const password = form.password.value.trim();
 
-    if (!username || !email || !password) {
-      alert('All fields are required.');
+    let error = '';
+
+    if (!username) {
+      error = 'Username is required.';
+    } else if (!/^[a-zA-Z0-9_]+$/.test(username)) {
+      error = 'Username can only contain letters, numbers, and underscores.';
+    } else if (!email) {
+      error = 'Email is required.';
+    } else if (!/^\S+@\S+\.\S+$/.test(email)) {
+      error = 'Enter a valid email address.';
+    } else if (!password) {
+      error = 'Password is required.';
+    } else if (password.length < 8) {
+      error = 'Password must be at least 8 characters.';
+    }
+
+    if (error) {
+      errorEl.textContent = error;
       return;
     }
 
+    errorEl.textContent = '';
     console.log('Registered:', { username, email });
     document.getElementById('registration-container').style.display = 'none';
   });

--- a/userstory.md
+++ b/userstory.md
@@ -1,3 +1,4 @@
 ## User Story list
 - User Story 0: Set up project backbone and basic game loop in JavaScript.
 - User Story 1a: Player Registration Form UI.
+- User Story 1b: Registration Input Validation.


### PR DESCRIPTION
## Summary
- display inline validation errors in the registration form
- validate username, email format and password length
- list new user story about input validation

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(fails: live-server not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d12cf8c88326b11a4ac51b26ebc9