### PR TITLE
Implement clan selection UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,43 @@
     #registration-form input[type="password"] {
       padding: 8px;
     }
+    #clan-selection-container {
+      display: none;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.7);
+      color: #fff;
+      overflow-y: auto;
+    }
+    #clan-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      justify-content: center;
+      padding: 20px;
+    }
+    .clan-option {
+      background: #333;
+      border: 2px solid transparent;
+      padding: 10px;
+      border-radius: 4px;
+      width: 220px;
+      cursor: pointer;
+    }
+    .clan-option.selected {
+      border-color: gold;
+    }
+    .clan-option h3 {
+      margin: 0 0 5px 0;
+      text-align: center;
+    }
+    .clan-option p {
+      margin: 0;
+      font-size: 0.9em;
+    }
   </style>
 </head>
 <body>
@@ -43,6 +80,32 @@
       <input type="password" id="password" placeholder="Password" required />
       <button type="submit">Register</button>
     </form>
+  </div>
+
+  <div id="clan-selection-container">
+    <h2 style="text-align:center;margin-top:20px;">Choose Your GOD Clan</h2>
+    <div id="clan-list">
+      <div class="clan-option" data-clan="ARES">
+        <h3>ARES</h3>
+        <p>+10% physical attack, bonus damage on critical hits, increased rage meter build-up</p>
+      </div>
+      <div class="clan-option" data-clan="ATHENA">
+        <h3>ATHENA</h3>
+        <p>+15% defense, reduced skill cooldowns, chance to counterattack when defending</p>
+      </div>
+      <div class="clan-option" data-clan="APOLLO">
+        <h3>APOLLO</h3>
+        <p>+10% magic attack, faster mana regeneration, more effective healing spells</p>
+      </div>
+      <div class="clan-option" data-clan="POSEIDON">
+        <h3>POSEIDON</h3>
+        <p>+10% stamina/endurance, chance to reduce elemental damage, faster movement in water/dungeons</p>
+      </div>
+      <div class="clan-option" data-clan="HEPHAESTUS">
+        <h3>HEPHAESTUS</h3>
+        <p>+10% fire resistance, increased weapon durability, bonus crafting/gem socket chances</p>
+      </div>
+    </div>
   </div>
   <!-- Load Phaser from CDN so deployments don't need local node_modules -->
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>

--- a/public/main.js
+++ b/public/main.js
@@ -29,6 +29,18 @@ const game = new Phaser.Game(config);
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('registration-form');
   const errorEl = document.getElementById('error-message');
+  const clanContainer = document.getElementById('clan-selection-container');
+  const clanOptions = document.querySelectorAll('.clan-option');
+  let selectedClan = null;
+
+  clanOptions.forEach(opt => {
+    opt.addEventListener('click', () => {
+      clanOptions.forEach(o => o.classList.remove('selected'));
+      opt.classList.add('selected');
+      selectedClan = opt.dataset.clan;
+    });
+  });
+
   if (!form) return;
   form.addEventListener('submit', e => {
     e.preventDefault();
@@ -60,6 +72,9 @@ document.addEventListener('DOMContentLoaded', () => {
     errorEl.textContent = '';
     console.log('Registered:', { username, email });
     document.getElementById('registration-container').style.display = 'none';
+    if (clanContainer) {
+      clanContainer.style.display = 'block';
+    }
   });
 });
 

--- a/userstory.md
+++ b/userstory.md
@@ -2,3 +2,4 @@
 - User Story 0: Set up project backbone and basic game loop in JavaScript.
 - User Story 1a: Player Registration Form UI.
 - User Story 1b: Registration Input Validation.
+- User Story 1c: Clan Selection UI.


### PR DESCRIPTION
## Summary
- add a clan selection panel with five clans
- enable selecting exactly one clan and highlight it
- show clan selection after successful registration
- record new user story

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864d277f2808326a086af2d58b451f7