### PR TITLE
Implement clan selection persistence

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,6 +43,11 @@
       color: #fff;
       overflow-y: auto;
     }
+    #selected-clan-message {
+      text-align: center;
+      margin-top: 10px;
+      font-weight: bold;
+    }
     #clan-list {
       display: flex;
       flex-wrap: wrap;
@@ -82,9 +87,10 @@
     </form>
   </div>
 
-  <div id="clan-selection-container">
-    <h2 style="text-align:center;margin-top:20px;">Choose Your GOD Clan</h2>
-    <div id="clan-list">
+    <div id="clan-selection-container">
+      <h2 style="text-align:center;margin-top:20px;">Choose Your GOD Clan</h2>
+      <div id="selected-clan-message"></div>
+      <div id="clan-list">
       <div class="clan-option" data-clan="ARES">
         <h3>ARES</h3>
         <p>+10% physical attack, bonus damage on critical hits, increased rage meter build-up</p>

--- a/public/main.js
+++ b/public/main.js
@@ -31,13 +31,29 @@ document.addEventListener('DOMContentLoaded', () => {
   const errorEl = document.getElementById('error-message');
   const clanContainer = document.getElementById('clan-selection-container');
   const clanOptions = document.querySelectorAll('.clan-option');
-  let selectedClan = null;
+  const clanMessage = document.getElementById('selected-clan-message');
+  let selectedClan = localStorage.getItem('selectedClan') || null;
+
+  if (selectedClan) {
+    clanOptions.forEach(o => {
+      if (o.dataset.clan === selectedClan) {
+        o.classList.add('selected');
+      }
+    });
+    if (clanMessage) {
+      clanMessage.textContent = `Selected Clan: ${selectedClan}`;
+    }
+  }
 
   clanOptions.forEach(opt => {
     opt.addEventListener('click', () => {
       clanOptions.forEach(o => o.classList.remove('selected'));
       opt.classList.add('selected');
       selectedClan = opt.dataset.clan;
+      localStorage.setItem('selectedClan', selectedClan);
+      if (clanMessage) {
+        clanMessage.textContent = `Selected Clan: ${selectedClan}`;
+      }
     });
   });
 

--- a/userstory.md
+++ b/userstory.md
@@ -3,3 +3,4 @@
 - User Story 1a: Player Registration Form UI.
 - User Story 1b: Registration Input Validation.
 - User Story 1c: Clan Selection UI.
+- User Story 1d: Save Clan Selection Locally.


### PR DESCRIPTION
## Summary
- add persistence of clan choice via `localStorage`
- show the stored clan to the user in a message area
- document new user story for clan persistence

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864d39738508326b322a2667d82e9d8