### PR TITLE
Implement monster battle trigger

### DIFF
--- a/__tests__/monster.test.js
+++ b/__tests__/monster.test.js
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+let create, update, tileSize, setHero, setInputs, setMonsters, getMonsters, getBattleState, setBattleState, mapData;
+
+describe('monster encounters', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    global.Phaser = { Game: jest.fn(), AUTO: 0, Input: { Keyboard: { KeyCodes: {} } } };
+    ({ create, update, tileSize, setHero, setInputs, setMonsters, getMonsters, getBattleState, setBattleState, mapData } = require('../public/main.js'));
+  });
+
+  test('create spawns monsters', () => {
+    const scene = {
+      add: {
+        graphics: () => ({ fillStyle: jest.fn(), fillRect: jest.fn() }),
+        rectangle: jest.fn(() => ({}))
+      },
+      input: { keyboard: { createCursorKeys: () => ({}), addKeys: () => ({}) } }
+    };
+    create.call(scene);
+    expect(getMonsters().length).toBeGreaterThan(0);
+  });
+
+  test('hero near monster triggers battle', () => {
+    const hero = { x: tileSize * 2 + tileSize / 2, y: tileSize * 2 + tileSize / 2, width: tileSize, height: tileSize };
+    setHero(hero);
+    setInputs({ left:{isDown:false}, right:{isDown:false}, up:{isDown:false}, down:{isDown:false} }, { left:{isDown:false}, right:{isDown:false}, up:{isDown:false}, down:{isDown:false} });
+    const monster = { sprite: {}, tileX: 2, tileY: 2 };
+    setMonsters([monster]);
+    setBattleState(false);
+    const ctx = { game:{ loop:{ delta: 16 } }, sys:{ game:{ config:{ width: tileSize * mapData[0].length, height: tileSize * mapData.length } } } };
+    update.call(ctx);
+    expect(getBattleState()).toBe(true);
+  });
+});

--- a/public/main.js
+++ b/public/main.js
@@ -47,6 +47,25 @@ const config = {
 let hero;
 let cursors;
 let wasd;
+let monsters = [];
+let inBattle = false;
+const monsterSpawns = [
+  { x: 5, y: 5 },
+  { x: 10, y: 8 }
+];
+
+function spawnMonsters(scene) {
+  monsters = monsterSpawns.map(pos => {
+    const sprite = scene.add.rectangle(
+      pos.x * tileSize + tileSize / 2,
+      pos.y * tileSize + tileSize / 2,
+      tileSize,
+      tileSize,
+      0x00ff00
+    );
+    return { sprite, tileX: pos.x, tileY: pos.y };
+  });
+}
 
 function preload() {
   // nothing to preload yet
@@ -65,6 +84,7 @@ function create() {
 
   // spawn hero on a walkable tile to ensure movement works
   hero = this.add.rectangle(tileSize + tileSize / 2, tileSize + tileSize / 2, tileSize, tileSize, 0xff0000);
+  spawnMonsters(this);
   cursors = this.input.keyboard.createCursorKeys();
   wasd = this.input.keyboard.addKeys({
     up: Phaser.Input.Keyboard.KeyCodes.W,
@@ -103,6 +123,19 @@ function update() {
   const height = this.sys.game.config.height;
   hero.x = Math.max(halfW, Math.min(width - halfW, hero.x));
   hero.y = Math.max(halfH, Math.min(height - halfH, hero.y));
+
+  const heroTileX = Math.floor(hero.x / tileSize);
+  const heroTileY = Math.floor(hero.y / tileSize);
+  monsters.forEach(m => {
+    if (
+      Math.abs(heroTileX - m.tileX) <= 1 &&
+      Math.abs(heroTileY - m.tileY) <= 1 &&
+      !inBattle
+    ) {
+      inBattle = true;
+      console.log('Battle start!');
+    }
+  });
 }
 
 const game = new Phaser.Game(config);
@@ -230,7 +263,11 @@ if (typeof module !== 'undefined' && module.exports) {
     update,
     getHero: () => hero,
     setHero: h => { hero = h; },
-    setInputs: (c, w) => { cursors = c; wasd = w; }
+    setInputs: (c, w) => { cursors = c; wasd = w; },
+    getMonsters: () => monsters,
+    setMonsters: m => { monsters = m; },
+    getBattleState: () => inBattle,
+    setBattleState: b => { inBattle = b; }
   };
 }
 

--- a/userstory.md
+++ b/userstory.md
@@ -8,3 +8,4 @@
 - User Story 3: Integrate CSS with Sass Preprocessor.
 - User Story 3a: Hero Movement in Dungeon.
 - User Story 3b: Basic Dungeon Map Rendering.
+- User Story 3c: Monster Encounter Trigger.


### PR DESCRIPTION
## Summary
- list new user story 3c
- spawn monsters and trigger battle on proximity
- expose helper methods for monsters
- add tests for monster encounters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68655abc59ac8326881c4d6dabb9f8bb