### PR TITLE
Increase monster turn delay

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -153,7 +153,7 @@ async function enemyPhase(msg) {
   turn = 'enemy';
   updateTurnIndicator();
   setCombatMessage(msg);
-  await delay(300);
+  await delay(1000);
   msg += ' ' + monsterTurn();
   if (heroStats.hp <= 0) {
     endBattle(msg + ' Hero defeated!');


### PR DESCRIPTION
## Summary
- add more delay before the monster takes its turn

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656d6ed7f08326ab46f5fa54a695ba