### PR TITLE
Improve battle scene layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,6 +86,6 @@
     <!-- Load Phaser from CDN so deployments don't need local node_modules -->
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
   <script src="validation.js"></script>
-  <script type="module" src="main.js"></script>
+  <script defer src="main.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -143,12 +143,15 @@ canvas {
   color: #fff;
   padding: 20px;
   z-index: 10;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 #combat-container .battle-panel {
+  flex: 1;
   display: flex;
   justify-content: space-around;
   align-items: center;
-  height: 100%;
 }
 #combat-container .combatant {
   text-align: center;
@@ -179,7 +182,6 @@ canvas {
 }
 #combat-container #combat-controls {
   text-align: center;
-  margin-top: 20px;
 }
 #combat-container #combat-controls button {
   margin: 0 5px;
@@ -190,6 +192,8 @@ canvas {
 #combat-container #combat-message {
   margin-top: 10px;
   text-align: center;
+  overflow-y: auto;
+  max-height: 40%;
 }
 
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
## Summary
- keep battle overlay within viewport
- convert combat log to show multiple messages
- ensure battle overlay uses flexbox layout
- load main script as deferred instead of module

## Testing
- `npm test` *(fails: End-to-end tests time out in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_686572b3c6f083268ee874fcaf464955