### PR TITLE
Add monster respawn system

### DIFF
--- a/__tests__/monster.test.js
+++ b/__tests__/monster.test.js
@@ -1,11 +1,28 @@
 /** @jest-environment jsdom */
-let create, update, tileSize, setHero, setInputs, setMonsters, getMonsters, getBattleState, setBattleState, mapData;
+let create, update, tileSize, setHero, setInputs, setMonsters, getMonsters, getBattleState, setBattleState, mapData, enterBattle, endBattle, checkRespawns, monsterSpawns, RESPAWN_DELAY;
 
 describe('monster encounters', () => {
   beforeEach(() => {
     jest.resetModules();
+    jest.useFakeTimers();
     global.Phaser = { Game: jest.fn(), AUTO: 0, Input: { Keyboard: { KeyCodes: {} } } };
-    ({ create, update, tileSize, setHero, setInputs, setMonsters, getMonsters, getBattleState, setBattleState, mapData } = require('../public/main.js'));
+    ({
+      create,
+      update,
+      tileSize,
+      setHero,
+      setInputs,
+      setMonsters,
+      getMonsters,
+      getBattleState,
+      setBattleState,
+      mapData,
+      enterBattle,
+      endBattle,
+      checkRespawns,
+      monsterSpawns,
+      RESPAWN_DELAY
+    } = require('../public/main.js'));
   });
 
   test('create spawns monsters', () => {
@@ -30,5 +47,27 @@ describe('monster encounters', () => {
     const ctx = { game:{ loop:{ delta: 16 } }, sys:{ game:{ config:{ width: tileSize * mapData[0].length, height: tileSize * mapData.length } } } };
     update.call(ctx);
     expect(getBattleState()).toBe(true);
+  });
+
+  test('monster respawns after cooldown', () => {
+    const scene = {
+      add: {
+        graphics: () => ({ fillStyle: jest.fn(), fillRect: jest.fn() }),
+        rectangle: jest.fn(() => ({}))
+      },
+      input: { keyboard: { createCursorKeys: () => ({}), addKeys: () => ({}) } }
+    };
+    create.call(scene);
+    const spawn = monsterSpawns[0];
+    const monster = getMonsters().find(m => m.spawn === spawn);
+    const initial = getMonsters().length;
+    document.body.innerHTML = '<div id="combat-container"></div><div id="turn-indicator"></div>';
+    enterBattle(monster);
+    endBattle();
+    expect(getMonsters().length).toBe(initial - 1);
+    expect(getMonsters().find(m => m.spawn === spawn)).toBeUndefined();
+    jest.advanceTimersByTime(RESPAWN_DELAY);
+    checkRespawns.call(scene, scene);
+    expect(getMonsters().find(m => m.spawn === spawn)).toBeDefined();
   });
 });

--- a/userstory.md
+++ b/userstory.md
@@ -12,3 +12,4 @@
 - User Story 3d: Turn-Based Combat Initiation.
 - User Story 3e: Basic Combat Actions.
 - User Story 9: Reward System After Combat.
+- User Story 10: Monster Respawn System.


### PR DESCRIPTION
## Summary
- implement respawn logic for dungeon monsters
- schedule monster respawn after defeat
- spawn monsters when cooldown expires
- export helpers for tests
- test respawn behaviour
- list new user story

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68657c7f69008326bccbd6154dfd4a7d