### PR TITLE
Fix delayed battle exit after defeat

### DIFF
--- a/__tests__/combat.test.js
+++ b/__tests__/combat.test.js
@@ -75,6 +75,8 @@ test('monster removed after defeat', async () => {
   setMonsters([monster]);
   enterBattle(monster);
   await attackAction();
+  jest.advanceTimersByTime(3000);
+  await flushTimers();
   expect(getMonsters().length).toBe(0);
   expect(monster.sprite.destroy).toHaveBeenCalled();
 });

--- a/public/main.js
+++ b/public/main.js
@@ -188,15 +188,20 @@ function handleRewards() {
   const msgEl = document.getElementById('reward-message');
   const container = document.getElementById('reward-container');
   if (msgEl) msgEl.textContent = `Earned ${reward.exp} XP`;
-  if (container) {
-    container.style.display = 'block';
-    setTimeout(() => {
-      container.style.display = 'none';
-      const lvlMsg = document.getElementById('level-up-message');
-      if (lvlMsg) lvlMsg.textContent = '';
-    }, 3000);
-  }
   checkLevelUp();
+  return new Promise(resolve => {
+    if (container) {
+      container.style.display = 'block';
+      setTimeout(() => {
+        container.style.display = 'none';
+        const lvlMsg = document.getElementById('level-up-message');
+        if (lvlMsg) lvlMsg.textContent = '';
+        resolve();
+      }, 3000);
+    } else {
+      resolve();
+    }
+  });
 }
 
 function showDamage(targetId, amount) {
@@ -289,9 +294,12 @@ async function attackAction() {
   let msg = `Hero attacks! Monster HP is ${currentMonster.stats.hp}.`;
   setCombatMessage(msg);
   if (currentMonster.stats.hp <= 0) {
-    handleRewards();
-    endBattle(msg + ' Monster defeated!');
-    return msg + ' Monster defeated!';
+    const finalMsg = msg + ' Monster defeated!';
+    setCombatMessage(finalMsg);
+    handleRewards().then(() => {
+      endBattle(finalMsg);
+    });
+    return finalMsg;
   }
   await delay(1000);
   return enemyPhase(msg);


### PR DESCRIPTION
## Summary
- keep combat on screen until reward phase completes
- adjust monster defeat test to wait for delayed battle end

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68674d5847c883268a5d728ba2983ddb