### PR TITLE
Add tests for weapon equip rules

### DIFF
--- a/__tests__/equipment.test.js
+++ b/__tests__/equipment.test.js
@@ -41,3 +41,27 @@ test('equipping one-handed clears two-handed weapon', () => {
   expect(document.getElementById('left-hand-slot').textContent).toBe('Sword');
   expect(document.getElementById('right-hand-slot').textContent).toBe('Empty');
 });
+
+test('equipping two-handed weapon replaces both one-handed weapons', () => {
+  const sword = { name: 'Sword', twoHanded: false };
+  const dagger = { name: 'Dagger', twoHanded: false };
+  equipWeapon('left', sword);
+  equipWeapon('right', dagger);
+  const gs = { name: 'Greatsword', twoHanded: true };
+  equipWeapon('left', gs);
+  expect(heroEquipment.left).toBe(gs);
+  expect(heroEquipment.right).toBe(gs);
+  expect(document.getElementById('left-hand-slot').textContent).toBe('Greatsword');
+  expect(document.getElementById('right-hand-slot').textContent).toBe('Greatsword');
+});
+
+test('one-handed weapons equip independently', () => {
+  const sword = { name: 'Sword', twoHanded: false };
+  const dagger = { name: 'Dagger', twoHanded: false };
+  equipWeapon('left', sword);
+  equipWeapon('right', dagger);
+  expect(heroEquipment.left).toBe(sword);
+  expect(heroEquipment.right).toBe(dagger);
+  expect(document.getElementById('left-hand-slot').textContent).toBe('Sword');
+  expect(document.getElementById('right-hand-slot').textContent).toBe('Dagger');
+});

--- a/userstory.md
+++ b/userstory.md
@@ -15,3 +15,4 @@
 - User Story 10: Monster Respawn System.
 - User Story 11: Hero Leveling and Stats Progression.
 - User Story 16: Hero Attribute Allocation.
+- User Story 22f: Weapon Equip Logic for One-Handed and Two-Handed Weapons.


### PR DESCRIPTION
## Summary
- cover weapon equip scenarios with new tests
- list new user story: Weapon Equip Logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68679f4470f8832683a49d5fbebbbfe5