### PR TITLE
Add Mage fireball ability

### DIFF
--- a/__tests__/spell.test.js
+++ b/__tests__/spell.test.js
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+let enterBattle, heroStats, castFireballAction, updateTurnIndicator;
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.useFakeTimers();
+  global.Phaser = { Game: jest.fn() };
+  ({ enterBattle, heroStats, castFireballAction, updateTurnIndicator } = require('../public/main.js'));
+  document.body.innerHTML = `
+    <div id="combat-container" style="display:none;">
+      <div class="battle-panel">
+        <div class="combatant">
+          <img id="hero-img" />
+          <div id="hero-stats" class="hp-bar"><div id="hero-hp-fill" class="hp-fill"></div></div>
+        </div>
+        <div class="combatant">
+          <img id="monster-img" />
+          <div id="monster-stats" class="hp-bar"><div id="monster-hp-fill" class="hp-fill"></div></div>
+        </div>
+      </div>
+      <div id="combat-controls">
+        <button id="attack-btn">Attack</button>
+        <button id="fireball-btn">Fireball</button>
+        <button id="defend-btn">Defend</button>
+        <div id="turn-indicator"></div>
+      </div>
+      <div id="combat-message"></div>
+    </div>`;
+});
+
+async function flushTimers() {
+  while (jest.getTimerCount() > 0) {
+    jest.runOnlyPendingTimers();
+    await Promise.resolve();
+  }
+}
+
+test('castFireball consumes mana and damages monster', async () => {
+  const monster = { stats: { hp: 30, maxHp: 30, atk: 0 } };
+  heroStats.mp = 20;
+  heroStats.mag = 7;
+  enterBattle(monster);
+  const promise = castFireballAction();
+  await flushTimers();
+  await promise;
+  expect(heroStats.mp).toBe(10);
+  expect(monster.stats.hp).toBe(18);
+});
+
+test('fireball button disabled when insufficient mana', () => {
+  heroStats.mp = 5;
+  updateTurnIndicator();
+  expect(document.getElementById('fireball-btn').disabled).toBe(true);
+});
+
+test('casting fireball with insufficient mana returns empty string', async () => {
+  const monster = { stats: { hp: 30, maxHp: 30, atk: 0 } };
+  heroStats.mp = 5;
+  enterBattle(monster);
+  const result = await castFireballAction();
+  expect(result).toBe('');
+  expect(monster.stats.hp).toBe(30);
+  expect(heroStats.mp).toBe(5);
+});

--- a/public/index.html
+++ b/public/index.html
@@ -84,6 +84,7 @@
       </div>
       <div id="combat-controls">
         <button id="attack-btn">Attack</button>
+        <button id="fireball-btn">Fireball</button>
         <button id="defend-btn">Defend</button>
         <div id="turn-indicator"></div>
       </div>

--- a/userstory.md
+++ b/userstory.md
@@ -35,3 +35,11 @@ weapon falls below 30% it is considered in **bad shape** and shown in red.
 - `degradeWeapon` reduces durability when an attack occurs.
 - `weaponDamage` factors durability into the damage calculation.
 - `updateEquipmentUI` updates slot text and status classes in real time.
+
+### User Story 20a Notes
+Implemented Fireball casting for the Mage. A new **Fireball** button appears in
+combat controls when it's the player's turn. The button becomes disabled if the
+hero has less than 10 MP. Casting the spell reduces MP immediately and damages
+the target using `MAG` plus a small base value. The existing attack action
+remains for weapon strikes. Added unit tests covering mana consumption, button
+state, and insufficient mana handling.


### PR DESCRIPTION
## Summary
- enable Fireball spell for mage characters
- show a Fireball button during player turn
- disable Fireball when mana is insufficient
- support casting with mana cost and magic-based damage
- test fireball functionality
- document feature in user story log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868057de07883268067ee040f88aa51