### PR TITLE
Add elemental icon display

### DIFF
--- a/__tests__/combat.test.js
+++ b/__tests__/combat.test.js
@@ -26,6 +26,7 @@ beforeEach(() => {
       <div id="combat-message"></div>
     </div>
     <div id="reward-container"><div id="reward-message"></div></div>`;
+  heroStats.critChance = 0;
 });
 
 async function flushTimers() {

--- a/__tests__/element.test.js
+++ b/__tests__/element.test.js
@@ -1,13 +1,15 @@
 /** @jest-environment jsdom */
 let create, getMonsters, enterBattle, castFireballAction,
-    heroStats, modifyMonsterResistance, updateMonsterInfo;
+    heroStats, modifyMonsterResistance, setMonsterElement, updateMonsterInfo,
+    ELEMENT_ICONS;
 
 beforeEach(() => {
   jest.resetModules();
   jest.useFakeTimers();
   global.Phaser = { Game: jest.fn(), Input: { Keyboard: { KeyCodes: {} } } };
   ({ create, getMonsters, enterBattle, castFireballAction,
-     heroStats, modifyMonsterResistance, updateMonsterInfo } = require('../public/main.js'));
+     heroStats, modifyMonsterResistance, setMonsterElement, updateMonsterInfo,
+     ELEMENT_ICONS } = require('../public/main.js'));
   document.body.innerHTML = `
     <div id="combat-container" style="display:none;">
       <div class="battle-panel">
@@ -85,4 +87,18 @@ test('modifyMonsterResistance affects damage calculation', async () => {
   await flushTimers();
   await promise;
   expect(monster.stats.hp).toBe(40 - Math.floor(base * (1 - 0.5)));
+});
+
+test('monster element icon updates with element', () => {
+  const monster = { element: 'Fire', resistances: {}, stats: { hp: 10, atk: 0 } };
+  document.body.innerHTML += '<img id="monster-element-icon">';
+  enterBattle(monster);
+  updateMonsterInfo();
+  let icon = document.getElementById('monster-element-icon');
+  expect(icon.src).toBe(ELEMENT_ICONS.fire);
+  expect(icon.title).toBe('Fire');
+  setMonsterElement(monster, 'Water');
+  updateMonsterInfo();
+  expect(icon.src).toBe(ELEMENT_ICONS.water);
+  expect(icon.title).toBe('Water');
 });

--- a/public/index.html
+++ b/public/index.html
@@ -79,6 +79,7 @@
         </div>
         <div class="combatant">
           <img id="monster-img" src="./assets/Enemy_Animations_Set/enemies-skeleton1_idle.png" />
+          <img id="monster-element-icon" class="element-icon" alt="element" />
           <div id="monster-stats" class="hp-bar"><div id="monster-hp-fill" class="hp-fill"></div></div>
         </div>
       </div>

--- a/public/main.js
+++ b/public/main.js
@@ -62,6 +62,14 @@ let heroStats = {
 };
 let heroEquipment = { left: null, right: null };
 const DEFAULT_RESISTANCES = { Physical: 0, Fire: 0, Water: 0 };
+const ELEMENT_ICONS = {
+  fire:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAP0lEQVR4AZ3B0QmAMBAFwb20efW9OlcjBgTNjzMsBvlQnAxyq6Z4GAaZmotBHgZLgOZlVFNMDYQ9gwbZMcgfB/zMFZLXHOqhAAAAAElFTkSuQmCC',
+  water:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAPklEQVR4AZXBwQ2AMAwEwd0mXaSbPBIJP4jgwQwPnXCQ0QmjlJtsnXAqZZFO+FIqWyecSllkdMIo5VUn/HUBN4sUVnEQkF8AAAAASUVORK5CYII=',
+  physical:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAALklEQVR4AaXBsQ0AMAjAsJSr+H/KV3RFSBVDbTq1GIJFsDhq8ZCZh04thmAR/LpHUgq4BM/ldgAAAABJRU5ErkJggg=='
+};
 const DURABILITY_LOSS_PER_USE = 5;
 const FIREBALL_COST = 10;
 const FIREBALL_BASE_DAMAGE = 5;
@@ -152,12 +160,18 @@ function updateHeroHUD() {
 
 function updateMonsterInfo() {
   const info = document.getElementById('monster-info');
+  const icon = document.getElementById('monster-element-icon');
   if (!info || !currentMonster) return;
   const res = currentMonster.resistances || {};
   const entries = Object.keys(res)
     .map(k => `${k} ${Math.round(res[k] * 100)}%`)
     .join(' ');
   info.textContent = `Element: ${currentMonster.element || 'Unknown'} | ${entries}`;
+  if (icon) {
+    const el = (currentMonster.element || 'Physical').toLowerCase();
+    icon.src = ELEMENT_ICONS[el] || '';
+    icon.title = currentMonster.element || 'Unknown';
+  }
 }
 
 function updateEquipmentUI() {
@@ -326,6 +340,12 @@ function scheduleRespawn(monster) {
 function modifyMonsterResistance(monster, element, delta) {
   if (!monster.resistances) monster.resistances = { ...DEFAULT_RESISTANCES };
   monster.resistances[element] = (monster.resistances[element] || 0) + delta;
+  updateMonsterInfo();
+}
+
+function setMonsterElement(monster, element) {
+  if (!monster) return;
+  monster.element = element;
   updateMonsterInfo();
 }
 
@@ -996,6 +1016,7 @@ if (typeof module !== 'undefined' && module.exports) {
     animateFireball,
     updateMonsterInfo,
     modifyMonsterResistance,
+    setMonsterElement,
     doubleShotAction,
     shieldBashAction,
     skillCooldowns,
@@ -1009,7 +1030,8 @@ if (typeof module !== 'undefined' && module.exports) {
     playerRewards,
     checkRespawns,
     monsterSpawns,
-    RESPAWN_DELAY
+    RESPAWN_DELAY,
+    ELEMENT_ICONS
   };
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -219,6 +219,7 @@ canvas {
   display: block;
 }
 #combat-container .combatant {
+  position: relative;
   text-align: center;
 }
 #combat-container .combatant img {
@@ -226,6 +227,19 @@ canvas {
   height: 64px;
   margin-bottom: 10px;
   border: 2px solid #fff;
+}
+
+#combat-container .element-icon {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  image-rendering: pixelated;
+  pointer-events: auto;
+}
+
+#monster-element-icon {
+  top: -4px;
+  right: -4px;
 }
 #combat-container .combatant .hp-bar {
   width: 70px;

--- a/userstory.md
+++ b/userstory.md
@@ -61,3 +61,11 @@ reduced according to these values via `applyResistance`. A helper
 battle and updates the display immediately. Unit tests verify that monsters are
 spawned with these properties, the UI reflects them, damage calculations respect
 resistances and changes apply correctly.
+
+### User Story 21b Notes
+Each monster now displays a small icon representing its elemental attribute. Icons
+are generated as Base64 PNG data URLs embedded directly in the code and shown
+next to the monster sprite in combat. `updateMonsterInfo` updates the icon source
+and tooltip text so it changes whenever a monster's element is modified through
+the new `setMonsterElement` helper. Tests ensure the icon image and title update
+correctly.


### PR DESCRIPTION
## Summary
- generate tiny PNG icons for elements
- display the element icon beside monsters in combat
- add helper `setMonsterElement` and update icon/tooltip
- test icon updates and fix combat tests
- document User Story 21b implementation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68681dd4a80083268378425ae673add1