### PR TITLE
Center hero using camera follow

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -43,10 +43,12 @@ townMapData[TOWN_DOOR.y][TOWN_DOOR.x] = 1;
 townMapData[TOWN_ENTRY.y][TOWN_ENTRY.x] = 1;
 
 const DUNGEON_ENTRY = { x: DUNGEON_DOOR.x, y: DUNGEON_DOOR.y + 1 };
+const VIEW_WIDTH = tileSize * 20;
+const VIEW_HEIGHT = tileSize * 15;
 const config = {
   type: Phaser.AUTO,
-  width: tileSize * mapData[0].length,
-  height: tileSize * mapData.length,
+  width: VIEW_WIDTH,
+  height: VIEW_HEIGHT,
   scene: [
     { key: "DungeonScene", preload, create, update },
     { key: "TownScene", preload: townPreload, create: townCreate, update: townUpdate }
@@ -890,6 +892,12 @@ function create() {
   } else {
     hero = this.add.rectangle(tileSize + tileSize / 2, tileSize + tileSize / 2, tileSize, tileSize, 0xff0000);
   }
+  if (this.cameras && this.cameras.main) {
+    const width = mapData[0].length * tileSize;
+    const height = mapData.length * tileSize;
+    this.cameras.main.setBounds(0, 0, width, height);
+    this.cameras.main.startFollow(hero, true);
+  }
   spawnMonsters(this);
   cursors = this.input.keyboard.createCursorKeys();
   wasd = this.input.keyboard.addKeys({
@@ -971,6 +979,12 @@ function townCreate(data = {}) {
     hero.setScale(1);
   } else {
     hero = this.add.rectangle(spawnX, spawnY, tileSize, tileSize, 0xff0000);
+  }
+  if (this.cameras && this.cameras.main) {
+    const width = townMapData[0].length * tileSize;
+    const height = townMapData.length * tileSize;
+    this.cameras.main.setBounds(0, 0, width, height);
+    this.cameras.main.startFollow(hero, true);
   }
   cursors = this.input.keyboard.createCursorKeys();
   wasd = this.input.keyboard.addKeys({


### PR DESCRIPTION
## Summary
- keep the hero centered on screen by following with the main camera
- set a viewport size smaller than the map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868c436a5388326b24761a265f72505