### PR TITLE
Implement companion inventory

### DIFF
--- a/__tests__/companion.test.js
+++ b/__tests__/companion.test.js
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+let addCompanion, removeCompanion, getInventory, updateInventoryUI, loadInventory;
+
+beforeEach(() => {
+  jest.resetModules();
+  document.body.innerHTML = '<ul id="companion-inventory"></ul>';
+  ({ addCompanion, removeCompanion, getInventory, updateInventoryUI, loadInventory } = require('../public/companion.js'));
+  localStorage.clear();
+  loadInventory();
+});
+
+test('addCompanion stores data and updates UI', () => {
+  const comp = { name: 'Lili', job: 'Healer', stats: { hp: 100, attack: 5, defense: 5, speed: 5 }, level: 1 };
+  addCompanion(comp);
+  expect(getInventory().length).toBe(1);
+  expect(JSON.parse(localStorage.getItem('companionInventory')).length).toBe(1);
+  updateInventoryUI();
+  expect(document.getElementById('companion-inventory').textContent).toContain('Lili');
+});
+
+test('removeCompanion deletes from inventory and UI', () => {
+  const comp = addCompanion({ name: 'Bell', job: 'Adventurer', stats: { hp: 90, attack: 12, defense: 6, speed: 8 }, level: 1 });
+  updateInventoryUI();
+  expect(document.getElementById('companion-inventory').textContent).toContain('Bell');
+  removeCompanion(comp.id);
+  expect(getInventory().length).toBe(0);
+  updateInventoryUI();
+  expect(document.getElementById('companion-inventory').textContent).not.toContain('Bell');
+});
+
+test('inventory persists after reload', () => {
+  const comp = addCompanion({ name: 'Haruhime', job: 'Support', stats: { hp: 80, attack: 8, defense: 4, speed: 7 }, level: 1 });
+  updateInventoryUI();
+  expect(document.getElementById('companion-inventory').textContent).toContain('Haruhime');
+  // reload module
+  jest.resetModules();
+  document.body.innerHTML = '<ul id="companion-inventory"></ul>';
+  ({ loadInventory, getInventory, updateInventoryUI } = require('../public/companion.js'));
+  loadInventory();
+  updateInventoryUI();
+  expect(getInventory().length).toBe(1);
+  expect(document.getElementById('companion-inventory').textContent).toContain('Haruhime');
+});

--- a/public/companion.js
+++ b/public/companion.js
@@ -1,0 +1,69 @@
+const STORAGE_KEY = 'companionInventory';
+const ID_KEY = 'companionIdCounter';
+let companionInventory = [];
+
+function generateId() {
+  const next = (parseInt(localStorage.getItem(ID_KEY) || '0', 10) + 1);
+  localStorage.setItem(ID_KEY, next);
+  return next;
+}
+
+function loadInventory() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  companionInventory = stored ? JSON.parse(stored) : [];
+}
+
+function saveInventory() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(companionInventory));
+}
+
+function getInventory() {
+  return companionInventory;
+}
+
+function addCompanion(companion) {
+  const obj = { ...companion };
+  if (!obj.id) obj.id = generateId();
+  companionInventory.push(obj);
+  saveInventory();
+  updateInventoryUI();
+  return obj;
+}
+
+function removeCompanion(id) {
+  const idx = companionInventory.findIndex(c => c.id === id);
+  if (idx !== -1) {
+    companionInventory.splice(idx, 1);
+    saveInventory();
+    updateInventoryUI();
+    return true;
+  }
+  return false;
+}
+
+function updateInventoryUI() {
+  const list = document.getElementById('companion-inventory');
+  if (!list) return;
+  list.innerHTML = '';
+  companionInventory.forEach(c => {
+    const li = document.createElement('li');
+    li.textContent = `${c.name} (${c.job}) Lv ${c.level}`;
+    list.appendChild(li);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadInventory();
+  updateInventoryUI();
+});
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    loadInventory,
+    saveInventory,
+    getInventory,
+    addCompanion,
+    removeCompanion,
+    updateInventoryUI
+  };
+}

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,10 @@
     <div>Left Hand: <span id="left-hand-slot" class="weapon-slot">Empty</span></div>
     <div>Right Hand: <span id="right-hand-slot" class="weapon-slot">Empty</span></div>
   </div>
+  <div id="companion-inventory-container">
+    <h2>Companions</h2>
+    <ul id="companion-inventory"></ul>
+  </div>
   <div id="registration-container">
     <form id="registration-form">
       <div id="error-message"></div>
@@ -109,8 +113,9 @@
     </div>
     <div id="dialogue-box"></div>
     <!-- Load Phaser from CDN so deployments don't need local node_modules -->
-    <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
   <script src="validation.js"></script>
   <script type="module" src="main.js"></script>
+  <script type="module" src="companion.js"></script>
 </body>
 </html>

--- a/userstory.md
+++ b/userstory.md
@@ -18,6 +18,7 @@
 - User Story 22f: Weapon Equip Logic for One-Handed and Two-Handed Weapons.
 - User Story 22g: Add Weapon Attributes and Integrate Them into Combat Calculations.
 - User Story 22b: Weapon Durability Tracking with Status Visualization.
+- User Story 31a: Companion Data Model and Inventory.
 
 ### User Story 22b Notes
 The durability system attaches a `durability` value to each weapon object. Durability
@@ -85,3 +86,13 @@ Add foundational abilities beyond Fireball, Double Shot, and Shield Bash.
 
 ### User Story 30 Notes
 The town now spawns three NPCs at random locations. Each NPC wanders around the map at its own speed and shows a short text bubble above its head when the hero approaches. Players can still press **E** or click an NPC to bring up a larger dialogue box. NPCs respawn whenever the player returns to town.
+
+### User Story 31a Notes
+Companion data uses a simple schema:
+`{ id, name, job, level, stats: { hp, attack, defense, speed } }`.
+All owned companions are stored in an array saved to `localStorage` under
+`companionInventory` with an incremental `companionIdCounter` for unique IDs.
+The `companion.js` module exposes `addCompanion`, `removeCompanion`, and
+`getInventory` helpers. On page load it restores saved companions and populates
+the new `#companion-inventory` list so the roster persists across sessions.
+Unit tests cover inventory operations, DOM updates, and persistence.


### PR DESCRIPTION
## Summary
- create `companion.js` module for companion data and storage
- display companion inventory list in UI
- load and save companions using localStorage
- test companion add/remove/persistence behaviour
- document design decisions in `userstory.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868cfde34c48326aa7ee66114bd2828