### PR TITLE
Add companion combat visuals

### DIFF
--- a/__tests__/combat.test.js
+++ b/__tests__/combat.test.js
@@ -105,7 +105,9 @@ test('monster removed after defeat', async () => {
   const monster = { stats: { hp: 10, atk: 0 }, sprite: { destroy: jest.fn() } };
   setMonsters([monster]);
   enterBattle(monster);
-  await attackAction();
+  const promise = attackAction();
+  jest.advanceTimersByTime(1000);
+  await promise;
   jest.advanceTimersByTime(3000);
   await flushTimers();
   expect(getMonsters().length).toBe(0);
@@ -116,7 +118,9 @@ test('rewards granted after defeating monster', async () => {
   const monster = { stats: { hp: 10, atk: 0 }, sprite: { destroy: jest.fn() } };
   setMonsters([monster]);
   enterBattle(monster);
-  await attackAction();
+  const promise = attackAction();
+  jest.advanceTimersByTime(1000);
+  await promise;
   expect(playerRewards.exp).toBeGreaterThan(0);
   expect(playerRewards.gold).toBeGreaterThan(0);
   expect(document.getElementById('reward-container').style.display).toBe('block');
@@ -152,7 +156,7 @@ test('companions render and attack sequentially', async () => {
   const promise = attackAction();
   await flushTimers();
   const delayCalls = spy.mock.calls.filter(c => c[1] === 300);
-  expect(delayCalls.length).toBeGreaterThanOrEqual(2);
+  expect(delayCalls.length).toBeGreaterThanOrEqual(companions.length + 1);
   await promise;
   spy.mockRestore();
 });

--- a/__tests__/combat.test.js
+++ b/__tests__/combat.test.js
@@ -1,11 +1,11 @@
 /** @jest-environment jsdom */
-let enterBattle, heroStats, attackAction, defendAction, setMonsters, getMonsters, playerRewards, equipWeapon, heroAttackPower;
+let enterBattle, heroStats, attackAction, defendAction, setMonsters, getMonsters, playerRewards, equipWeapon, heroAttackPower, companions;
 
 beforeEach(() => {
   jest.resetModules();
   jest.useFakeTimers();
   global.Phaser = { Game: jest.fn() };
-  ({ enterBattle, heroStats, attackAction, defendAction, setMonsters, getMonsters, playerRewards, equipWeapon, heroAttackPower } = require('../public/main.js'));
+  ({ enterBattle, heroStats, attackAction, defendAction, setMonsters, getMonsters, playerRewards, equipWeapon, heroAttackPower, companions } = require('../public/main.js'));
   document.body.innerHTML = `
     <div id="combat-container" style="display:none;">
       <div class="battle-panel">
@@ -13,6 +13,7 @@ beforeEach(() => {
           <img id="hero-img" />
           <div id="hero-stats" class="hp-bar"><div id="hero-hp-fill" class="hp-fill"></div></div>
         </div>
+        <div id="companion-container" class="companion-panel"></div>
         <div class="combatant">
           <img id="monster-img" />
           <div id="monster-stats" class="hp-bar"><div id="monster-hp-fill" class="hp-fill"></div></div>
@@ -135,6 +136,23 @@ test('monster action delayed with six 1 second steps', async () => {
   await flushTimers();
   const oneSecondCalls = spy.mock.calls.filter(c => c[1] === 1000);
   expect(oneSecondCalls.length).toBe(6);
+  await promise;
+  spy.mockRestore();
+});
+
+test('companions render and attack sequentially', async () => {
+  const monster = { stats: { hp: 50, atk: 0, maxHp: 50 } };
+  heroStats.hp = 100;
+  companions.push({ name: 'Ally1', stats: { atk: 3 } });
+  companions.push({ name: 'Ally2', stats: { atk: 4 } });
+  enterBattle(monster);
+  expect(document.getElementById('companion-img-0')).not.toBeNull();
+  expect(document.getElementById('companion-img-1')).not.toBeNull();
+  const spy = jest.spyOn(global, 'setTimeout');
+  const promise = attackAction();
+  await flushTimers();
+  const delayCalls = spy.mock.calls.filter(c => c[1] === 300);
+  expect(delayCalls.length).toBeGreaterThanOrEqual(2);
   await promise;
   spy.mockRestore();
 });

--- a/public/index.html
+++ b/public/index.html
@@ -81,6 +81,7 @@
           <img id="hero-img" class="combatant-img" src="./assets/character%20and%20tileset/Dungeon_Character.png" />
           <div id="hero-stats" class="hp-bar"><div id="hero-hp-fill" class="hp-fill"></div></div>
         </div>
+        <div id="companion-container" class="companion-panel"></div>
         <div class="combatant">
           <img id="monster-img" class="combatant-img" src="./assets/Enemy_Animations_Set/enemies-skeleton1_idle.png" />
           <img id="monster-element-icon" class="element-icon" alt="element" />

--- a/public/main.js
+++ b/public/main.js
@@ -765,12 +765,15 @@ async function attackAction() {
   damage = applyResistance(currentMonster, damage, 'Physical');
   animateAttack('hero-img', 'monster-img', damage, crit);
   currentMonster.stats.hp -= damage;
+  setCombatMessage(crit ? 'Hero critically hits!' : 'Hero attacks!');
+  await delay(300);
   let compTotal = 0;
   for (let i = 0; i < companions.length; i++) {
     const c = companions[i];
     compTotal += c.stats.atk;
     animateAttack(`companion-img-${i}`, 'monster-img', c.stats.atk, false);
     currentMonster.stats.hp -= c.stats.atk;
+    setCombatMessage(`${c.name} attacks!`);
     await delay(300);
   }
   if (heroEquipment.left) degradeWeapon(heroEquipment.left);

--- a/public/main.js
+++ b/public/main.js
@@ -396,6 +396,8 @@ function endBattle(result) {
   }
   const icon = document.getElementById('monster-element-icon');
   if (icon) icon.style.display = 'none';
+  const compContainer = document.getElementById('companion-container');
+  if (compContainer) compContainer.innerHTML = '';
   currentMonster = null;
   turn = 'player';
   updateTurnIndicator();
@@ -476,6 +478,22 @@ function spawnCompanionSprites(scene) {
   });
 }
 
+function renderCompanionCombatants() {
+  const container = document.getElementById('companion-container');
+  if (!container) return;
+  container.innerHTML = '';
+  companions.forEach((comp, i) => {
+    const div = document.createElement('div');
+    div.className = 'combatant';
+    const img = document.createElement('img');
+    img.id = `companion-img-${i}`;
+    img.className = 'combatant-img';
+    img.src = './assets/character%20and%20tileset/Dungeon_Character.png';
+    div.appendChild(img);
+    container.appendChild(div);
+  });
+}
+
 function updateCompanionSprites(delta) {
   companionSprites.forEach((c, i) => {
     const targetX = hero.x + (i + 1) * tileSize;
@@ -532,6 +550,7 @@ function enterBattle(monster) {
   if (heroEl) heroEl.className = 'hp-bar';
   if (monsterEl) monsterEl.className = 'hp-bar';
   updateHPBars();
+  renderCompanionCombatants();
   updateMonsterInfo();
   combat.style.display = 'block';
   const msgEl = document.getElementById('combat-message');
@@ -747,11 +766,13 @@ async function attackAction() {
   animateAttack('hero-img', 'monster-img', damage, crit);
   currentMonster.stats.hp -= damage;
   let compTotal = 0;
-  companions.forEach(c => {
+  for (let i = 0; i < companions.length; i++) {
+    const c = companions[i];
     compTotal += c.stats.atk;
-    showDamage('monster-img', c.stats.atk);
-  });
-  currentMonster.stats.hp -= compTotal;
+    animateAttack(`companion-img-${i}`, 'monster-img', c.stats.atk, false);
+    currentMonster.stats.hp -= c.stats.atk;
+    await delay(300);
+  }
   if (heroEquipment.left) degradeWeapon(heroEquipment.left);
   if (heroEquipment.right && heroEquipment.right !== heroEquipment.left) {
     degradeWeapon(heroEquipment.right);

--- a/public/style.css
+++ b/public/style.css
@@ -237,7 +237,7 @@
 #combat-container .combatant .combatant-img {
   width: 64px;
   height: 64px;
-  margin-bottom: 10px;
+  margin-bottom: 0;
   border: 2px solid #fff;
 }
 #combat-container .combatant .hp-bar {

--- a/public/style.css
+++ b/public/style.css
@@ -203,6 +203,11 @@
   align-items: flex-end;
   z-index: 2;
 }
+#combat-container .companion-panel {
+  display: flex;
+  flex-direction: row-reverse;
+  gap: 10px;
+}
 #combat-container .ground {
   position: absolute;
   bottom: 25%;

--- a/userstory.md
+++ b/userstory.md
@@ -105,5 +105,5 @@ Unit tests cover inventory operations, DOM updates, and persistence.
 Companions now appear in the combat interface. When a battle starts the game
 creates image elements for each party member in a new companion panel beside the
 hero. During the hero's attack phase each companion lunges at the enemy one by
-one, dealing their damage with a short delay. The monster's HP updates after
-every strike and the combat message summarizes the total damage dealt.
+one, dealing their damage with a short delay. All combatants stand on the ground
+and attacks play sequentially so the player can follow each strike.

--- a/userstory.md
+++ b/userstory.md
@@ -100,3 +100,10 @@ The `companion.js` module exposes `addCompanion`, `removeCompanion`, and
 `getInventory` helpers. On page load it restores saved companions and populates
 the new `#companion-inventory` list so the roster persists across sessions.
 Unit tests cover inventory operations, DOM updates, and persistence.
+
+### User Story 31e Notes
+Companions now appear in the combat interface. When a battle starts the game
+creates image elements for each party member in a new companion panel beside the
+hero. During the hero's attack phase each companion lunges at the enemy one by
+one, dealing their damage with a short delay. The monster's HP updates after
+every strike and the combat message summarizes the total damage dealt.


### PR DESCRIPTION
## Summary
- show companions in the battle panel
- animate each companion's attack sequentially
- reset companion area when battle ends
- update tests for new companion display
- record notes for story 31e

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68695d62550c8326b588f755f81a76d4